### PR TITLE
[#18] 프로필 페이지 내 프로필 항목

### DIFF
--- a/what_team_my_team/_components/LinkAvatar.tsx
+++ b/what_team_my_team/_components/LinkAvatar.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import React, { useEffect, useState } from 'react'
+import AvatarRoot, { AvatarRootProps } from './ui/Avatar/Root'
+import AvatarImage from './ui/Avatar/Image'
+import AvatarFallback from './ui/Avatar/Fallback'
+
+interface ProfileAvatarProps extends AvatarRootProps {
+  url: string
+}
+
+const LinkAvatar = ({ url, ...props }: ProfileAvatarProps) => {
+  const [iconPath, setIconPath] = useState<string>('')
+  const [alt, setAlt] = useState<string>('')
+
+  useEffect(() => {
+    setIconPath(checkMiddleDomain(url))
+  }, [url])
+
+  const getMiddleDomain = (url: string) => {
+    const protocolRemoved = url.replace(/^(https?:\/\/)?/i, '')
+    const splitBySlash = protocolRemoved.split('/')
+    const middleDomain = splitBySlash.length > 1 ? splitBySlash[0] : ''
+
+    return middleDomain
+  }
+  const checkMiddleDomain = (url: string) => {
+    const checkedMiddle = getMiddleDomain(url)
+    if (checkedMiddle.includes('github')) {
+      setAlt('github')
+      return '/assets/github.svg'
+    } else if (checkedMiddle.includes('notion')) {
+      setAlt('notion')
+      return '/assets/notion.svg'
+    } else {
+      setAlt('link')
+      return '/assets/link.svg'
+    }
+  }
+  return (
+    <AvatarRoot {...props}>
+      <AvatarImage src={iconPath} alt={alt} />
+      <AvatarFallback>{alt}</AvatarFallback>
+    </AvatarRoot>
+  )
+}
+
+export default LinkAvatar

--- a/what_team_my_team/_components/MSWComponents.tsx
+++ b/what_team_my_team/_components/MSWComponents.tsx
@@ -4,7 +4,10 @@ import { useEffect } from 'react'
 
 export const MswComponent = () => {
   useEffect(() => {
-    if (process.env.NODE_ENV === 'development') {
+    if (
+      process.env.NODE_ENV === 'development' &&
+      process.env.NEXT_PUBLIC_API_MOCKING === 'enabled'
+    ) {
       if (typeof window === 'undefined') {
         ;(async () => {
           const { server } = await import('@/_mocks/server')

--- a/what_team_my_team/_components/ProfileAvatar.tsx
+++ b/what_team_my_team/_components/ProfileAvatar.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import React from 'react'
+import AvatarRoot, { AvatarRootProps } from './ui/Avatar/Root'
+import AvatarImage from './ui/Avatar/Image'
+import AvatarFallback from './ui/Avatar/Fallback'
+
+interface ProfileAvatarProps extends AvatarRootProps {
+  imgUrl: string
+  alt: string
+}
+
+const ProfileAvatar = ({ imgUrl, alt, ...props }: ProfileAvatarProps) => {
+  return (
+    <AvatarRoot {...props}>
+      <AvatarImage src={imgUrl} alt={alt} />
+      <AvatarFallback>{alt}</AvatarFallback>
+    </AvatarRoot>
+  )
+}
+
+export default ProfileAvatar

--- a/what_team_my_team/_components/ui/Avatar/Fallback.tsx
+++ b/what_team_my_team/_components/ui/Avatar/Fallback.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import * as AvatarPrimitive from '@radix-ui/react-avatar'
+import { VariantProps, cva } from 'class-variance-authority'
+
+const AvatarFallbackVariants = cva(
+  `flex w-full h-full item-center justify-center bg-white text-indigo-6 font-md`,
+)
+
+interface AvatarFallbackProps
+  extends AvatarPrimitive.AvatarFallbackProps,
+    VariantProps<typeof AvatarFallbackVariants> {}
+
+const AvatarFallback = ({
+  children,
+  className,
+  ...props
+}: AvatarFallbackProps) => {
+  return (
+    <AvatarPrimitive.Fallback
+      className={(AvatarFallbackVariants(), className)}
+      {...props}
+    >
+      {children}
+    </AvatarPrimitive.Fallback>
+  )
+}
+
+export default AvatarFallback

--- a/what_team_my_team/_components/ui/Avatar/Image.tsx
+++ b/what_team_my_team/_components/ui/Avatar/Image.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { cn } from '@/_lib/utils'
+import * as AvatarPrimitive from '@radix-ui/react-avatar'
+import { type VariantProps, cva } from 'class-variance-authority'
+
+const AvatarImageVariants = cva(`w-full h-full object-cover rounded-[inherit]`)
+
+export interface AvatarImageProps
+  extends AvatarPrimitive.AvatarImageProps,
+    VariantProps<typeof AvatarImageVariants> {}
+
+const AvatarImage = ({ className, ...props }: AvatarImageProps) => {
+  return (
+    <AvatarPrimitive.Image
+      className={cn(AvatarImageVariants(), className)}
+      {...props}
+    />
+  )
+}
+
+export default AvatarImage

--- a/what_team_my_team/_components/ui/Avatar/Root.tsx
+++ b/what_team_my_team/_components/ui/Avatar/Root.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { cn } from '@/_lib/utils'
+import * as AvatarPrimitive from '@radix-ui/react-avatar'
+import { type VariantProps, cva } from 'class-variance-authority'
+
+const AvatarRootVariants = cva(`inline-flex items-center justify-center`, {
+  variants: {
+    size: {
+      small: 'w-8 h-8',
+      large: 'w-20 h-20',
+      link: 'w-6 h-6',
+    },
+    rounded: {
+      full: 'rounded-full',
+    },
+  },
+  defaultVariants: {
+    size: 'small',
+    rounded: 'full',
+  },
+})
+
+export interface AvatarRootProps
+  extends AvatarPrimitive.AvatarProps,
+    VariantProps<typeof AvatarRootVariants> {}
+
+const AvatarRoot = ({
+  children,
+  size,
+  rounded,
+  className,
+  ...props
+}: AvatarRootProps) => {
+  return (
+    <AvatarPrimitive.Root
+      {...props}
+      className={cn(AvatarRootVariants({ size, rounded }), className)}
+    >
+      {children}
+    </AvatarPrimitive.Root>
+  )
+}
+
+export default AvatarRoot

--- a/what_team_my_team/_components/ui/Avatar/index.ts
+++ b/what_team_my_team/_components/ui/Avatar/index.ts
@@ -1,0 +1,1 @@
+export * from '@/_components/ui/Avatar'

--- a/what_team_my_team/_lib/axios.ts
+++ b/what_team_my_team/_lib/axios.ts
@@ -13,6 +13,7 @@ axiosInstance.interceptors.request.use(
   function (config) {
     config.headers['X-from'] = 'web'
     config.withCredentials = true
+
     return config
   },
   function (error) {

--- a/what_team_my_team/_lib/hydrate.client.tsx
+++ b/what_team_my_team/_lib/hydrate.client.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import {
+  HydrationBoundary,
+  HydrationBoundaryProps,
+} from '@tanstack/react-query'
+
+function Hydrate(props: HydrationBoundaryProps) {
+  return <HydrationBoundary {...props} />
+}
+
+export default Hydrate

--- a/what_team_my_team/_mocks/datas.ts
+++ b/what_team_my_team/_mocks/datas.ts
@@ -47,4 +47,37 @@ const EntireData: EntireMember = {
   ],
 }
 
-export { AssignData, EntireData }
+const ProfileData = {
+  profile: {
+    name: '강태원',
+    student_num: '201811318',
+    id: 2,
+    image: 'https://avatars.githubusercontent.com/u/71972587?v=4',
+    is_approved: false,
+    is_staff: false,
+    position: '백엔드',
+    explain: '열심히 하겠습니다!',
+  },
+  urls: [
+    {
+      url: 'https://velog.io/@taegong_s',
+    },
+    {
+      url: 'www.github.com/fnzksxl',
+    },
+  ],
+  tech: [
+    {
+      name: 'FastAPI',
+    },
+    {
+      name: 'Django',
+    },
+    {
+      name: 'MySQL',
+    },
+  ],
+  is_owner: true,
+}
+
+export { AssignData, EntireData, ProfileData }

--- a/what_team_my_team/_mocks/handlers.ts
+++ b/what_team_my_team/_mocks/handlers.ts
@@ -1,5 +1,5 @@
 import { HttpResponse, http } from 'msw'
-import { AssignData, EntireData } from './datas'
+import { AssignData, EntireData, ProfileData } from './datas'
 
 export const handlers = [
   http.get(`*/admin/user/manage`, () => {
@@ -16,5 +16,8 @@ export const handlers = [
   }),
   http.delete(`*/admin/user/list`, () => {
     return HttpResponse.json({ success: true })
+  }),
+  http.get(`*/user/profile/*`, () => {
+    return HttpResponse.json(ProfileData)
   }),
 ]

--- a/what_team_my_team/_services/mutations/useDeleteMember.ts
+++ b/what_team_my_team/_services/mutations/useDeleteMember.ts
@@ -6,16 +6,18 @@ interface DeleteMemberResponse {
   success: boolean
 }
 
-const deleteMember = () => {
+const deleteMember = (userIds: number) => {
+  console.log(userIds)
+  const body = { ids: userIds.toLocaleString() }
   const response = axiosInstance
-    .delete('/admin/user/list')
+    .delete('/admin/user/list', { data: body })
     .then(({ data }) => data)
 
   return response
 }
 
 const useDeleteMember = () => {
-  const { mutate } = useMutation<DeleteMemberResponse, AxiosError, string>({
+  const { mutate } = useMutation<DeleteMemberResponse, AxiosError, number>({
     mutationFn: deleteMember,
   })
 

--- a/what_team_my_team/_services/mutations/useMemberAccept.ts
+++ b/what_team_my_team/_services/mutations/useMemberAccept.ts
@@ -2,8 +2,12 @@ import axiosInstance from '@/_lib/axios'
 import { useMutation } from '@tanstack/react-query'
 
 const memberAccept = (id: number) => {
+  const body = {
+    ids: id.toLocaleString(),
+  }
+
   const response = axiosInstance
-    .patch(`/admin/user/manage/${id}`)
+    .patch(`/admin/user/manage`, body)
     .then(({ data }) => data)
 
   return response

--- a/what_team_my_team/_services/mutations/useMemberReject.ts
+++ b/what_team_my_team/_services/mutations/useMemberReject.ts
@@ -2,8 +2,12 @@ import axiosInstance from '@/_lib/axios'
 import { useMutation } from '@tanstack/react-query'
 
 const memberReject = (userId: number) => {
+  const body = {
+    ids: userId.toLocaleString(),
+  }
+
   const response = axiosInstance
-    .delete(`/admin/user/manage/${userId}`)
+    .delete(`/admin/user/manage`, { data: body })
     .then(({ data }) => data)
 
   return response

--- a/what_team_my_team/_services/mutations/useSignup.ts
+++ b/what_team_my_team/_services/mutations/useSignup.ts
@@ -20,7 +20,7 @@ const signup = (data: SignupVariables) => {
     student_num: data.studentNum,
     name: data.name,
   }
-  console.log(body)
+
   const response = axiosInstance
     .post<SignupResponse>('/auth/github/finish', body)
     .then(({ data }) => data)

--- a/what_team_my_team/_services/queries/useUserProfile.ts
+++ b/what_team_my_team/_services/queries/useUserProfile.ts
@@ -1,0 +1,81 @@
+import axiosInstance from '@/_lib/axios'
+import { useQuery } from '@tanstack/react-query'
+import { AxiosError } from 'axios'
+
+interface UserProfileReturn {
+  profile: {
+    name: string
+    student_num: string
+    id: number
+    image: string
+    is_approved: boolean
+    is_staff: boolean
+    position: string
+    explain: string
+  }
+  urls: { url: string }[]
+  tech: { name: string }[]
+  is_owner: boolean
+}
+export interface SelectedUserProfile {
+  profile: {
+    name: string
+    studentNum: string
+    id: number
+    image: string
+    isApproved: boolean
+    isStaff: boolean
+    position: string
+    explain: string
+  }
+  urls: { url: string }[]
+  tech: { name: string }[]
+  isOwner: boolean
+}
+
+export const getUserProfile = (userId: string) => {
+  const response = axiosInstance
+    .get(`/user/profile/${userId}`)
+    .then(({ data }) => {
+      return data
+    })
+
+  return response
+}
+
+export const USER_PROFILE_KEY = 'profile'
+
+const useUserProfile = (userId: string) => {
+  const userProfileQuery = useQuery<
+    UserProfileReturn,
+    AxiosError,
+    SelectedUserProfile
+  >({
+    queryFn: () => getUserProfile(userId),
+    queryKey: [USER_PROFILE_KEY, userId],
+    select: (data) => {
+      const selectedUrls = data.urls.map((url) => url)
+      const selectedTechs = data.tech.map((tech) => tech)
+      const selectedData: SelectedUserProfile = {
+        profile: {
+          name: data.profile.name,
+          studentNum: data.profile.student_num,
+          id: data.profile.id,
+          image: data.profile.image,
+          isApproved: data.profile.is_approved,
+          isStaff: data.profile.is_staff,
+          position: data.profile.position,
+          explain: data.profile.explain,
+        },
+        urls: selectedUrls,
+        tech: selectedTechs,
+        isOwner: data.is_owner,
+      }
+
+      return selectedData
+    },
+  })
+  return userProfileQuery
+}
+
+export default useUserProfile

--- a/what_team_my_team/app/(admin)/admin/(member)/entire/_components/ManageDropdown.tsx
+++ b/what_team_my_team/app/(admin)/admin/(member)/entire/_components/ManageDropdown.tsx
@@ -21,7 +21,7 @@ import useDeleteMember from '@/_services/mutations/useDeleteMember'
 import useEntireMemberList from '@/_services/queries/useEntireMemberList'
 
 interface ManageDropdownProps {
-  userId: string
+  userId: number
 }
 
 const ManageDropdown = ({ userId }: ManageDropdownProps) => {

--- a/what_team_my_team/app/(profile)/profile/[slug]/ProfileSideMenu.tsx
+++ b/what_team_my_team/app/(profile)/profile/[slug]/ProfileSideMenu.tsx
@@ -1,0 +1,14 @@
+const ProfileSideMenu = () => {
+  return (
+    <aside className="flex flex-col w-full max-w-[240px]">
+      <div className="flex flex-col gap-8 mb-40">
+        <span className="text-xl text-gray-6">프로필</span>
+        <span className="text-xl text-gray-6">내 활동</span>
+        <span className="text-xl text-gray-6">팀 관리</span>
+      </div>
+      <span className="text-xl text-red-6">로그아웃</span>
+    </aside>
+  )
+}
+
+export default ProfileSideMenu

--- a/what_team_my_team/app/(profile)/profile/[slug]/_components/BasicInfo.tsx
+++ b/what_team_my_team/app/(profile)/profile/[slug]/_components/BasicInfo.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import ProfileAvatar from '@/_components/ProfileAvatar'
+import Button from '@/_components/ui/Button'
+import { SelectedUserProfile } from '@/_services/queries/useUserProfile'
+import Link from 'next/link'
+import React from 'react'
+
+const BasicInfo = ({ data }: { data: SelectedUserProfile }) => {
+  return (
+    <div className="flex justify-between mb-12">
+      <div className="flex gap-4">
+        <ProfileAvatar
+          imgUrl={data?.profile.image}
+          alt={data.profile.name}
+          size={'large'}
+        />
+        <div className="flex flex-col">
+          <span className="text-xl font-bold">{data.profile.name}</span>
+          <div className="flex flex-col">
+            <span className="text-xs text-gray-6">
+              {data.profile.isApproved ? '정회원' : '준회원'}
+            </span>
+            <span className="text-sm">{data.profile.studentNum}</span>
+          </div>
+        </div>
+      </div>
+      {data.isOwner && (
+        <Button variant={'lined'}>
+          <Link href={`/profile/${data.profile.id}/setting`}>설정</Link>
+        </Button>
+      )}
+    </div>
+  )
+}
+
+export default BasicInfo

--- a/what_team_my_team/app/(profile)/profile/[slug]/_components/LinkInfo.tsx
+++ b/what_team_my_team/app/(profile)/profile/[slug]/_components/LinkInfo.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import LinkAvatar from '@/_components/LinkAvatar'
+import React from 'react'
+
+interface LinkInfoProps {
+  urls: { url: string }[]
+}
+
+const LinkInfo = ({ urls }: LinkInfoProps) => {
+  return (
+    <div>
+      <h3 className="text-base mb-2">링크</h3>
+      <ul className="flex flex-col gap-2">
+        {urls.map(({ url }, idx) => (
+          <li key={`${url}-${idx}`} className="flex items-center gap-2">
+            <LinkAvatar size={'link'} url={url} />
+            <a href={url} className="text-sm ml-2">
+              {url}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+export default LinkInfo

--- a/what_team_my_team/app/(profile)/profile/[slug]/_components/MyExplainInfo.tsx
+++ b/what_team_my_team/app/(profile)/profile/[slug]/_components/MyExplainInfo.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import React from 'react'
+
+interface MyExplainInfoProps {
+  explain: string
+}
+
+const MyExplainInfo = ({ explain }: MyExplainInfoProps) => {
+  return (
+    <div>
+      <h3 className="text-base mb-2">자기 소개</h3>
+      <div className="border border-gray-4 rounded-sm py-2 px-2">
+        <span className="text-sm">{explain}</span>
+      </div>
+    </div>
+  )
+}
+
+export default MyExplainInfo

--- a/what_team_my_team/app/(profile)/profile/[slug]/_components/PositionInfo.tsx
+++ b/what_team_my_team/app/(profile)/profile/[slug]/_components/PositionInfo.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import React from 'react'
+
+interface PositionInfoProps {
+  position: string
+}
+
+const PositionInfo = ({ position }: PositionInfoProps) => {
+  return (
+    <div>
+      <h3 className="text-base mb-2">주 포지션</h3>
+      <div className="border border-gray-4 rounded-sm py-2 px-2">
+        <span className="text-sm">{position}</span>
+      </div>
+    </div>
+  )
+}
+
+export default PositionInfo

--- a/what_team_my_team/app/(profile)/profile/[slug]/_components/ProfileContainer.tsx
+++ b/what_team_my_team/app/(profile)/profile/[slug]/_components/ProfileContainer.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import useUserProfile from '@/_services/queries/useUserProfile'
+import React from 'react'
+import BasicInfo from './BasicInfo'
+import LinkInfo from './LinkInfo'
+import MyExplainInfo from './MyExplainInfo'
+import TechInfo from './TechInfo'
+import PositionInfo from './PositionInfo'
+
+interface ProfileContainerProps {
+  userId: string
+}
+
+const ProfileContainer = ({ userId }: ProfileContainerProps) => {
+  const { data, isLoading } = useUserProfile(userId)
+
+  return (
+    <>
+      {isLoading && <div>로딩중...</div>}
+      {data && (
+        <div className="w-full max-w-[1060px]">
+          <BasicInfo data={data} />
+          <div className="flex flex-col gap-4">
+            <PositionInfo position={data.profile.position} />
+            <TechInfo tech={data.tech} />
+            <MyExplainInfo explain={data.profile.explain} />
+            <LinkInfo urls={data.urls} />
+          </div>
+        </div>
+      )}
+    </>
+  )
+}
+
+export default ProfileContainer

--- a/what_team_my_team/app/(profile)/profile/[slug]/_components/TechInfo.tsx
+++ b/what_team_my_team/app/(profile)/profile/[slug]/_components/TechInfo.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import React from 'react'
+
+interface TechInfoProps {
+  tech: { name: string }[]
+}
+
+const TechInfo = ({ tech }: TechInfoProps) => {
+  return (
+    <div>
+      <h3 className="text-base mb-2">기술 스택</h3>
+      <ul className="flex gap-1 border border-gray-4 rounded-sm py-2 px-2">
+        {tech.length === 0 ? (
+          <span>없음</span>
+        ) : (
+          tech.map(({ name }, idx) => (
+            <li
+              key={`${name}-${idx}}`}
+              className="text-xs bg-gray-4 rounded-sm p-1"
+            >
+              {name}
+            </li>
+          ))
+        )}
+      </ul>
+    </div>
+  )
+}
+
+export default TechInfo

--- a/what_team_my_team/app/(profile)/profile/[slug]/layout.tsx
+++ b/what_team_my_team/app/(profile)/profile/[slug]/layout.tsx
@@ -1,0 +1,14 @@
+import ProfileSideMenu from './ProfileSideMenu'
+
+const layout = ({ children }: Readonly<{ children: React.ReactNode }>) => {
+  return (
+    <div className="flex justify-center w-full">
+      <div className="flex w-full max-w-[840px]">
+        <ProfileSideMenu />
+        {children}
+      </div>
+    </div>
+  )
+}
+
+export default layout

--- a/what_team_my_team/app/(profile)/profile/[slug]/page.tsx
+++ b/what_team_my_team/app/(profile)/profile/[slug]/page.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import ProfileContainer from './_components/ProfileContainer'
+import { getQueryClient } from '@/app/getQueryClient'
+import {
+  USER_PROFILE_KEY,
+  getUserProfile,
+} from '@/_services/queries/useUserProfile'
+import { dehydrate } from '@tanstack/react-query'
+import Hydrate from '@/_lib/hydrate.client'
+
+const ProfilePage = async ({ params }: { params: { slug: string } }) => {
+  const userId = params.slug
+
+  const queryClient = getQueryClient()
+  await queryClient.prefetchQuery({
+    queryKey: [USER_PROFILE_KEY, userId],
+    queryFn: () => getUserProfile(userId),
+  })
+  const dehydratedState = dehydrate(queryClient)
+
+  return (
+    <Hydrate state={dehydratedState}>
+      <div className="w-full">
+        <ProfileContainer userId={userId} />
+      </div>
+    </Hydrate>
+  )
+}
+
+export default ProfilePage

--- a/what_team_my_team/app/(profile)/profile/[slug]/setting/page.tsx
+++ b/what_team_my_team/app/(profile)/profile/[slug]/setting/page.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+const page = () => {
+  return <div>hello</div>
+}
+
+export default page

--- a/what_team_my_team/app/getQueryClient.ts
+++ b/what_team_my_team/app/getQueryClient.ts
@@ -1,0 +1,4 @@
+import { QueryClient } from '@tanstack/react-query'
+import { cache } from 'react'
+
+export const getQueryClient = cache(() => new QueryClient())

--- a/what_team_my_team/package-lock.json
+++ b/what_team_my_team/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@radix-ui/react-accordion": "^1.1.2",
         "@radix-ui/react-alert-dialog": "^1.0.5",
+        "@radix-ui/react-avatar": "^1.0.4",
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
         "@radix-ui/react-form": "^0.0.3",
@@ -3616,6 +3617,32 @@
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-primitive": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.0.4.tgz",
+      "integrity": "sha512-kVK2K7ZD3wwj3qhle0ElXhOjbezIgyl2hVvgwfIdexL3rN6zJmy5AqqIf+D31lxVppdzV8CjAfZ6PklkmInZLw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/what_team_my_team/package.json
+++ b/what_team_my_team/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-alert-dialog": "^1.0.5",
+    "@radix-ui/react-avatar": "^1.0.4",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-form": "^0.0.3",

--- a/what_team_my_team/stories/ProfileAvatar.stories.ts
+++ b/what_team_my_team/stories/ProfileAvatar.stories.ts
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import ProfileAvatar from '@/_components/ProfileAvatar'
+
+const meta = {
+  title: 'Components/ProfileAvatar',
+  component: ProfileAvatar,
+} satisfies Meta<typeof ProfileAvatar>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Primary: Story = {
+  args: {
+    imgUrl:
+      'https://images.unsplash.com/photo-1492633423870-43d1cd2775eb?&w=128&h=128&dpr=2&q=80',
+    alt: 'taegong',
+    size: 'large',
+  },
+}


### PR DESCRIPTION
**## #️⃣ 연관된 이슈** 
> ex) #이슈번호
- [#18]

---

**## 📝 작업 내용**
> ex) 소셜 로그인 연동
- 
![image](https://github.com/whatTeamNaeTeam/FE/assets/122659293/82155eb0-19c5-4f63-b02c-d1462a6b15f6)
프로필 페이지의 프로필 항목입니다.

설정버튼을 통해 프로필 편집 페이지로 이동할 수 있습니다.


---

**## 📢 참고사항**
> ex) Issue 내용과 달라진 점
- 공통 avatar 컴포넌트를 작업하였습니다.
- 공통 avatar 컴포넌트를 이용한 프로필 avatar 컴포넌트를 작업하였습니다.
- 공통 avatar 컴포넌트를 이용한 링크 icon 컴포넌트를 작업하였습니다.
- 프로필 사이드 메뉴의 상호작용이 미구현 상태 입니다.
- 프로필 사이드 메뉴의 로그아웃 버튼이 미구현 상태입니다.
- 상단 공통 navigation 이 구현되지 않은 상태입니다.
- 프로필 설정 버튼의 css 가 수정 예정입니다.