### PR TITLE
[#29] 이메일 인증 코드 발급 및 체크 로직

### DIFF
--- a/what_team_my_team/_services/mutations/useEmailAccess.ts
+++ b/what_team_my_team/_services/mutations/useEmailAccess.ts
@@ -1,0 +1,52 @@
+import axiosInstance from '@/_lib/axios'
+import { useMutation } from '@tanstack/react-query'
+import { AxiosError } from 'axios'
+
+type Email = string
+interface CheckCodeVariables {
+  email: Email
+  code: string
+}
+
+const getEmailCode = (email: string) => {
+  const body = {
+    email,
+  }
+
+  const response = axiosInstance
+    .post('/auth/email', body)
+    .then(({ data }) => data)
+
+  return response
+}
+
+const checkEmailCode = (email: string, code: string) => {
+  const body = {
+    email,
+    code,
+  }
+
+  const response = axiosInstance
+    .patch('/auth/email', body)
+    .then(({ data }) => data)
+
+  return response
+}
+
+const useEmailCode = () => {
+  const getCodeMutation = useMutation<unknown, AxiosError, { email: Email }>({
+    mutationFn: ({ email }) => getEmailCode(email),
+  })
+
+  const checkCodeMutation = useMutation<
+    unknown,
+    AxiosError,
+    CheckCodeVariables
+  >({
+    mutationFn: ({ email, code }) => checkEmailCode(email, code),
+  })
+
+  return { getCodeMutation, checkCodeMutation }
+}
+
+export default useEmailCode


### PR DESCRIPTION
**## #️⃣ 연관된 이슈** 
> ex) #이슈번호
- [#29]

---

**## 📝 작업 내용**
- 이메일 인증 코드를 발급 및 체크하는 로직입니다.

---

**## 📢 참고사항**
- 유효한 api 형식인지 체크되지 않았습니다. 회원가입 페이지와 함께 검증할 예정입니다.