### PR TITLE
Refact 회원가입페이지

### DIFF
--- a/what_team_my_team/_components/AuthFormInput.tsx
+++ b/what_team_my_team/_components/AuthFormInput.tsx
@@ -1,32 +1,23 @@
+'use client'
+
+import { UserRegisterFormValueType } from '@/app/(auth)/signup/_components/SignupContainer'
 import React from 'react'
-import { FieldErrors, UseFormRegisterReturn } from 'react-hook-form'
+import { ControllerRenderProps } from 'react-hook-form'
 
 interface FormInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
-  type: string
-  id: string
-  label: string
-  register: UseFormRegisterReturn
-  errors: FieldErrors
+  field: ControllerRenderProps<UserRegisterFormValueType>
 }
 
-const AuthFormInput = ({
-  id,
-  label,
-  register,
-  errors,
-  ...props
-}: FormInputProps) => {
+const AuthFormInput = ({ field, ...props }: FormInputProps) => {
   return (
-    <div className="flex flex-col w-full mb-4">
-      <label htmlFor={id} className="text-sm mb-2 font-bold">
-        {label}
-      </label>
-      <div className="w-full p-2 border focus-within:border-gray-6 rounded-md mb-2">
-        <input id={id} {...register} className="outline-none" {...props} />
-      </div>
-      {errors[id]?.message && (
-        <p className="text-red-8 text-sm">{`${errors[id]?.message}`}</p>
-      )}
+    <div className="flex justify-between p-2 border focus-within:border-gray-6 rounded-md w-60">
+      <input
+        value={field.value}
+        onChange={field.onChange}
+        ref={field.ref}
+        className="w-full text-sm outline-none disabled:bg-inherit disabled:text-gray-6"
+        {...props}
+      />
     </div>
   )
 }

--- a/what_team_my_team/_components/AuthFormInput.tsx
+++ b/what_team_my_team/_components/AuthFormInput.tsx
@@ -8,9 +8,9 @@ interface FormInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   field: ControllerRenderProps<UserRegisterFormValueType>
 }
 
-const AuthFormInput = ({ field, ...props }: FormInputProps) => {
+const AuthFormInput = ({ field, children, ...props }: FormInputProps) => {
   return (
-    <div className="flex justify-between p-2 border focus-within:border-gray-6 rounded-md w-60">
+    <div className="flex justify-between items-center p-2 border focus-within:border-gray-6 rounded-md w-60">
       <input
         value={field.value}
         onChange={field.onChange}
@@ -18,6 +18,7 @@ const AuthFormInput = ({ field, ...props }: FormInputProps) => {
         className="w-full text-sm outline-none disabled:bg-inherit disabled:text-gray-6"
         {...props}
       />
+      {children}
     </div>
   )
 }

--- a/what_team_my_team/_components/ui/Button.tsx
+++ b/what_team_my_team/_components/ui/Button.tsx
@@ -18,7 +18,7 @@ const ButtonVariants = cva(
       },
       size: {
         default: 'px-4 text-base h-[36px]',
-        sm: 'px-2 text-sm h-[24px]',
+        sm: 'px-2 text-sm h-[30px]',
         lg: 'px-8 text-lg',
         full: 'w-full text-lg',
         icon: 'h-10 w-10',

--- a/what_team_my_team/_mocks/handlers.ts
+++ b/what_team_my_team/_mocks/handlers.ts
@@ -32,4 +32,10 @@ export const handlers = [
   http.post(`*/team/apply/*`, () => {
     return HttpResponse.json(ApplyResponseData)
   }),
+  http.post(`*/auth/email`, () => {
+    return HttpResponse.json({ detail: 'Success to Send Email' })
+  }),
+  http.patch(`*/auth/email`, () => {
+    return HttpResponse.json({ detail: 'Success to Send Email' })
+  }),
 ]

--- a/what_team_my_team/_services/mutations/useSignup.ts
+++ b/what_team_my_team/_services/mutations/useSignup.ts
@@ -13,12 +13,16 @@ interface SignupResponse {
 interface SignupVariables {
   studentNum: string
   name: string
+  email: string
+  validCode: string
 }
 
 const signup = (data: SignupVariables) => {
   const body = {
     student_num: data.studentNum,
     name: data.name,
+    email: data.email,
+    code: data.validCode,
   }
 
   const response = axiosInstance
@@ -29,11 +33,15 @@ const signup = (data: SignupVariables) => {
 }
 
 const useSignup = () => {
-  const { mutate } = useMutation<SignupResponse, AxiosError, SignupVariables>({
+  const signupMutation = useMutation<
+    SignupResponse,
+    AxiosError,
+    SignupVariables
+  >({
     mutationFn: signup,
   })
 
-  return { mutate }
+  return { signupMutation }
 }
 
 export default useSignup

--- a/what_team_my_team/app/(auth)/signup/_components/EmailInput.tsx
+++ b/what_team_my_team/app/(auth)/signup/_components/EmailInput.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import React from 'react'
+import AuthFormInput from '@/_components/AuthFormInput'
+import {
+  REGISTER_FIELD_NAMES,
+  UserRegisterFormValueType,
+} from './SignupContainer'
+import { Control, useController } from 'react-hook-form'
+import Button from '@/_components/ui/Button'
+
+interface EmailInputProps {
+  control: Control<UserRegisterFormValueType>
+  handleGetEmailValid: (email: string) => void
+  isValidChecked: boolean
+}
+
+const EmailInput = ({
+  control,
+  handleGetEmailValid,
+  isValidChecked,
+}: EmailInputProps) => {
+  const emailRegex = /^[\w.-]+@[a-zA-Z\d.-]+\.[a-zA-Z]{2,}$/
+
+  const {
+    field,
+    fieldState: { error },
+  } = useController<UserRegisterFormValueType>({
+    name: REGISTER_FIELD_NAMES.email,
+    control,
+  })
+
+  return (
+    <>
+      <label
+        htmlFor={REGISTER_FIELD_NAMES.email}
+        className="inline-block text-sm mb-2 font-bold"
+      >
+        이메일 *
+      </label>
+      <div className="flex items-center gap-2">
+        <AuthFormInput
+          type="email"
+          id={REGISTER_FIELD_NAMES.email}
+          field={field}
+          placeholder="이메일주소(아이디 찾기에 사용됩니다.)"
+          disabled={isValidChecked}
+        />
+        <Button
+          type="button"
+          size={'sm'}
+          disabled={!emailRegex.test(field.value) || isValidChecked}
+          onClick={() => handleGetEmailValid(field.value)}
+          className="w-16"
+        >
+          인증
+        </Button>
+      </div>
+      {error && <p className="text-red-8 text-sm">{`${error.message}`}</p>}
+    </>
+  )
+}
+
+export default EmailInput

--- a/what_team_my_team/app/(auth)/signup/_components/NameInput.tsx
+++ b/what_team_my_team/app/(auth)/signup/_components/NameInput.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import React from 'react'
+import AuthFormInput from '@/_components/AuthFormInput'
+import { Control, useController } from 'react-hook-form'
+import {
+  REGISTER_FIELD_NAMES,
+  UserRegisterFormValueType,
+} from './SignupContainer'
+
+interface NameInputProps {
+  control: Control<UserRegisterFormValueType>
+}
+
+const NameInput = ({ control }: NameInputProps) => {
+  const { field } = useController<UserRegisterFormValueType>({
+    name: REGISTER_FIELD_NAMES.name,
+    control,
+  })
+
+  return (
+    <>
+      <label
+        htmlFor={REGISTER_FIELD_NAMES.name}
+        className="inline-block text-sm mb-2 font-bold"
+      >
+        이름 *
+      </label>
+      <AuthFormInput
+        type="string"
+        id={REGISTER_FIELD_NAMES.name}
+        field={field}
+        placeholder="ex)홍길동"
+        maxLength={7}
+      />
+    </>
+  )
+}
+
+export default NameInput

--- a/what_team_my_team/app/(auth)/signup/_components/SignupContainer.tsx
+++ b/what_team_my_team/app/(auth)/signup/_components/SignupContainer.tsx
@@ -1,27 +1,84 @@
 'use client'
 
-import AuthFormInput from '@/_components/AuthFormInput'
 import React, { useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import useSignup from '@/_services/mutations/useSignup'
 import SignupModal from '@/_components/SignupModal'
 import Button from '@/_components/ui/Button'
+import useEmailCode from '@/_services/mutations/useEmailAccess'
+import ValidCodeInput from './ValidCodeInput'
+import NameInput from './NameInput'
+import StudentNumInput from './StudentNumInput'
+import EmailInput from './EmailInput'
+import ValidTimer from './ValidTimer'
+import { useRouter } from 'next/navigation'
 
-interface FormValueType {
-  studentNum: string
-  name: string
+export type UserRegisterFormValueType = {
+  [K in keyof typeof REGISTER_FIELD_NAMES]: string
 }
+
+export const REGISTER_FIELD_NAMES = {
+  studentNum: 'studentNum',
+  name: 'name',
+  email: 'email',
+  validCode: 'validCode',
+} as const
 
 const SignupContainer = () => {
   const [isModalOpen, setIsModalOpen] = useState(false)
-  const {
-    handleSubmit,
-    register,
-    formState: { errors },
-  } = useForm<FormValueType>()
-  const { mutate } = useSignup()
-  const handleSignup: SubmitHandler<FormValueType> = (data) => {
-    mutate(data, {
+  const [canValid, setCanValid] = useState<boolean>(false)
+  const [isValidChecked, setIsValidChecked] = useState<boolean>(false)
+  const [isValidTimer, setIsValidTimer] = useState<boolean>(false)
+  const [validTimer, setValidTimer] = useState<number | null>(null)
+  const [isValidError, setIsValidError] = useState<boolean>(false)
+  const [validErrorMessage, setValidErrorMessage] = useState<string>('')
+
+  const router = useRouter()
+  const { control, handleSubmit, watch } = useForm<UserRegisterFormValueType>()
+  const { signupMutation } = useSignup()
+
+  const { getCodeMutation, checkCodeMutation } = useEmailCode()
+
+  const handleGetEmailValid = (email: string) => {
+    getCodeMutation.mutate(
+      { email },
+      {
+        onSuccess: () => {
+          alert('입력하신 이메일로 인증코드가 발급되었습니다.')
+          setCanValid(true)
+          setIsValidTimer(true)
+          setValidTimer(300)
+        },
+        onError: (error) => {
+          if (error.response?.status === 401) {
+            alert('로그인이 만료되었습니다.')
+            router.push('/signin')
+          }
+        },
+      },
+    )
+  }
+
+  const handleValid = (code: string) => {
+    checkCodeMutation.mutate(
+      { email: watch(REGISTER_FIELD_NAMES.email), code: code },
+      {
+        onSuccess: () => {
+          setIsValidChecked(true)
+          setIsValidTimer(false)
+          setIsValidError(false)
+        },
+        onError: (error) => {
+          // 상세 에러 분기 처리 필요
+          setValidErrorMessage('코드가 일치하지 않습니다.')
+          console.log(error)
+        },
+      },
+    )
+  }
+
+  const handleSignup: SubmitHandler<UserRegisterFormValueType> = (data) => {
+    signupMutation.mutate(data, {
       onSuccess: () => {
         setIsModalOpen(true)
       },
@@ -32,32 +89,40 @@ const SignupContainer = () => {
   }
 
   return (
-    <div className="flex flex-col items-center justify-center w-[320px] h-[320px] border mt-[120px]">
+    <div className="flex flex-col items-center justify-center border mt-[120px]">
       <form
         className="flex flex-col w-full p-12"
         onSubmit={handleSubmit(handleSignup)}
       >
-        <AuthFormInput
-          type="string"
-          id="name"
-          label="이름 *"
-          register={register('name', { required: '이름을 입력하세요.' })}
-          placeholder="ex)홍길동"
-          maxLength={7}
-          errors={errors}
-        />
-        <AuthFormInput
-          type="string"
-          id="studentNum"
-          label="학번 *"
-          register={register('studentNum', {
-            required: '학번을 입력해주세요.',
-          })}
-          placeholder="ex)201812379"
-          maxLength={9}
-          errors={errors}
-        />
-        <Button type="submit">확인 완료</Button>
+        <div className="mb-2">
+          <NameInput control={control} />
+        </div>
+        <div className="mb-2">
+          <StudentNumInput control={control} />
+        </div>
+        <div className="mb-2">
+          <EmailInput
+            control={control}
+            handleGetEmailValid={handleGetEmailValid}
+            isValidChecked={isValidChecked}
+          />
+        </div>
+        {canValid && (
+          <div className="mb-2">
+            <ValidCodeInput
+              control={control}
+              handleValid={handleValid}
+              isValidChecked={isValidChecked}
+            />
+            {isValidError && <span>{validErrorMessage}</span>}
+            {isValidTimer && (
+              <ValidTimer timer={validTimer} setTimer={setValidTimer} />
+            )}
+          </div>
+        )}
+        <Button type="submit" disabled={!isValidChecked}>
+          회원가입
+        </Button>
       </form>
       {isModalOpen && (
         <SignupModal open={isModalOpen} setOpen={setIsModalOpen} />

--- a/what_team_my_team/app/(auth)/signup/_components/StudentNumInput.tsx
+++ b/what_team_my_team/app/(auth)/signup/_components/StudentNumInput.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import React from 'react'
+import AuthFormInput from '@/_components/AuthFormInput'
+import {
+  REGISTER_FIELD_NAMES,
+  UserRegisterFormValueType,
+} from './SignupContainer'
+import { Control, useController } from 'react-hook-form'
+
+interface StudentNumInputProps {
+  control: Control<UserRegisterFormValueType>
+}
+
+const StudentNumInput = ({ control }: StudentNumInputProps) => {
+  const { field } = useController<UserRegisterFormValueType>({
+    name: REGISTER_FIELD_NAMES.studentNum,
+    control,
+  })
+
+  return (
+    <>
+      <label
+        htmlFor={REGISTER_FIELD_NAMES.studentNum}
+        className="inline-block text-sm mb-2 font-bold"
+      >
+        학번 *
+      </label>
+      <AuthFormInput
+        type="string"
+        id={REGISTER_FIELD_NAMES.studentNum}
+        field={field}
+        placeholder="ex)201812379"
+        maxLength={9}
+      />
+    </>
+  )
+}
+
+export default StudentNumInput

--- a/what_team_my_team/app/(auth)/signup/_components/ValidCodeInput.tsx
+++ b/what_team_my_team/app/(auth)/signup/_components/ValidCodeInput.tsx
@@ -8,6 +8,7 @@ import {
   REGISTER_FIELD_NAMES,
   UserRegisterFormValueType,
 } from './SignupContainer'
+import { FaCheckCircle } from 'react-icons/fa'
 
 interface ValidCodeInputProps {
   control: Control<UserRegisterFormValueType>
@@ -41,7 +42,9 @@ const ValidCodeInput = ({
           field={field}
           placeholder="인증코드 6자리를 압력해주세요."
           disabled={isValidChecked}
-        />
+        >
+          {isValidChecked && <FaCheckCircle className="text-green-6" />}
+        </AuthFormInput>
         <Button
           type="button"
           size={'sm'}

--- a/what_team_my_team/app/(auth)/signup/_components/ValidCodeInput.tsx
+++ b/what_team_my_team/app/(auth)/signup/_components/ValidCodeInput.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import React from 'react'
+import AuthFormInput from '@/_components/AuthFormInput'
+import Button from '@/_components/ui/Button'
+import { Control, useController } from 'react-hook-form'
+import {
+  REGISTER_FIELD_NAMES,
+  UserRegisterFormValueType,
+} from './SignupContainer'
+
+interface ValidCodeInputProps {
+  control: Control<UserRegisterFormValueType>
+  handleValid: (code: string) => void
+  isValidChecked: boolean
+}
+
+const ValidCodeInput = ({
+  control,
+  handleValid,
+  isValidChecked,
+}: ValidCodeInputProps) => {
+  const { field } = useController<UserRegisterFormValueType>({
+    name: REGISTER_FIELD_NAMES.validCode,
+    control,
+  })
+
+  return (
+    <>
+      <label
+        htmlFor={REGISTER_FIELD_NAMES.validCode}
+        className="inline-block text-sm mb-2 font-bold"
+      >
+        인증코드 *
+      </label>
+      <div className="flex items-center gap-2 mb-1">
+        <AuthFormInput
+          type="string"
+          id={REGISTER_FIELD_NAMES.validCode}
+          maxLength={6}
+          field={field}
+          placeholder="인증코드 6자리를 압력해주세요."
+          disabled={isValidChecked}
+        />
+        <Button
+          type="button"
+          size={'sm'}
+          disabled={!field.value || field.value?.length < 6 || isValidChecked}
+          onClick={() => handleValid(field.value)}
+          className="w-16"
+        >
+          확인
+        </Button>
+      </div>
+    </>
+  )
+}
+
+export default ValidCodeInput

--- a/what_team_my_team/app/(auth)/signup/_components/ValidTimer.tsx
+++ b/what_team_my_team/app/(auth)/signup/_components/ValidTimer.tsx
@@ -1,0 +1,53 @@
+'use client'
+import React, { useEffect } from 'react'
+
+interface ValidTimerProps {
+  timer: number | null
+  setTimer: React.Dispatch<React.SetStateAction<number | null>>
+}
+
+const ValidTimer = ({ timer, setTimer }: ValidTimerProps) => {
+  const formatTime = (timer: number) => {
+    const minutes = Math.floor(timer / 60)
+    const seconds = timer % 60
+
+    return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`
+  }
+
+  useEffect(() => {
+    if (timer === null) {
+      return
+    }
+
+    const id = setInterval(() => {
+      setTimer((prevTimer) => {
+        if (prevTimer !== null && prevTimer > 0) {
+          return prevTimer - 1
+        } else {
+          clearInterval(id)
+          return prevTimer
+        }
+      })
+    }, 1000)
+
+    return () => clearInterval(id)
+  }, [timer, setTimer])
+
+  if (timer === null) {
+    return null
+  }
+
+  return (
+    <div className="flex justify-end w-full text-xs text-gray-6">
+      {timer > 0 ? (
+        <span>{formatTime(timer)}</span>
+      ) : (
+        <span className="text-red-8">
+          인증 시간이 만료되었습니다. 다시 인증해주세요.
+        </span>
+      )}
+    </div>
+  )
+}
+
+export default ValidTimer


### PR DESCRIPTION
**## #️⃣ 연관된 이슈** 
- [#30]

---

**## 📝 작업 내용**
- 회원가입 페이지(/signup) 에 이메일 인증을 도입하였습니다. 
![image](https://github.com/whatTeamNaeTeam/FE/assets/122659293/00abaaba-8137-446b-81f1-d0aff6726104)
이메일 형식을 충족하지 못했을 때는 인증 버튼이 비활성화 됩니다.



![image](https://github.com/whatTeamNaeTeam/FE/assets/122659293/0070df82-a77c-4d17-978d-35e7ee666111)
(활성화 상태)



- 인증 버튼을 누르게 되면 성공적으로 인증코드가 해당 이메일로 발송되었으면 인증코드 6자리를 입력할 수 있는 인증코드 input 이 나타내게 됩니다. 인증코드 input container 하단 우측에 5분의 시간 제한 타이머가 있습니다.
![image](https://github.com/whatTeamNaeTeam/FE/assets/122659293/ad87bcc1-ba17-4475-bf87-a990a3a6964c)


인증코드 6자리를 입력하게 되면 확인 버튼이 활성화됩니다.
확인 버튼을 누르게 되면 입력한 인증 코드가 발급 해준 코드와 일치하는지 확인하는 api가 동작하게 됩니다.

![image](https://github.com/whatTeamNaeTeam/FE/assets/122659293/a870a00f-9391-4dbb-8be7-67438890ebdf)
인증코드가 일치하는 것을 확인이 되면 체크 표시와 함께 이메일 인증 input, 버튼, 인증 코드 input, 버튼이 비활성화 되게 됩니다.

- AuthFormInput 컴포넌트의 내부를 input 만 담당하게 변경하였습니다. 컴포넌트 내부의 input 태그가 useForm 훅의 control 에 의존하게 변경하였습니다(기존 register).


- signup 페이지의 각각의 input을 컴포넌트화 하였습니다.


- 공통 버튼 컴포넌트 size variants 중 sm 의 높이를 수정하였습니다.


- signup container의 넓이를 수정하였습니다.

---

**## 📢 참고사항**
- 이메일 인증 및 코드 유효 api 의 에러 분기를 처리하지않았습니다.(추후 변경 예정)
