### PR TITLE
[#44] 토큰 refresh 무한 요청 버그 해결

### DIFF
--- a/what_team_my_team/_lib/axios.ts
+++ b/what_team_my_team/_lib/axios.ts
@@ -37,9 +37,14 @@ axiosInstance.interceptors.response.use(
     return response
   },
   async function (error) {
+    if (error.config.url === '/auth/token/refresh') {
+      return Promise.reject(error)
+    }
+
     if (error.response.status === 401 || error.response.status === 403) {
       try {
         await getNewAccessToken()
+
         const originalRequest = error.config
 
         return await axiosInstance(originalRequest)


### PR DESCRIPTION
**## #️⃣ 연관된 이슈** 
[#44]

---

**## 📝 작업 내용**
axios interceptor의 error 부분에서 refresh token api이면 바로 error 를 return하게 하여 해결하였습니다.

---

**## 📢 참고사항**
