### PR TITLE
[#47] 프로필 페이지 내 프로필 리팩토링

### DIFF
--- a/what_team_my_team/_hook/useHandleLogout.ts
+++ b/what_team_my_team/_hook/useHandleLogout.ts
@@ -1,4 +1,4 @@
-import useLogout from '@/_services/queries/useLogout'
+import useLogout from '@/_services/mutations/useLogout'
 import { isLoggedInState, userState } from '@/_stores/atoms/user'
 import { useSetAtom } from 'jotai'
 

--- a/what_team_my_team/_services/mutations/useLogout.ts
+++ b/what_team_my_team/_services/mutations/useLogout.ts
@@ -4,7 +4,7 @@ import { isLoggedInState, userState } from '@/_stores/atoms/user'
 import { useSetAtom } from 'jotai'
 
 const logoutApi = async () => {
-  const response = await axiosInstance.delete('/auth/logout')
+  const response = await axiosInstance.post('/auth/logout')
 
   return response
 }

--- a/what_team_my_team/_services/queries/useUserProfile.ts
+++ b/what_team_my_team/_services/queries/useUserProfile.ts
@@ -1,46 +1,33 @@
 import axiosInstance from '@/_lib/axios'
+import {
+  convertSnakeToCamel,
+  ConvertSnakeToCamel,
+} from '@/_utils/convertSnakeToCamel'
 import { useQuery } from '@tanstack/react-query'
 import { AxiosError } from 'axios'
 
-interface UserProfileReturn {
+export interface UserProfileReturn {
   profile: {
     name: string
     student_num: string
     id: number
-    image: string
+    image_url: string
     is_approved: boolean
     is_staff: boolean
     position: string
     explain: string
   }
-  urls: { url: string }[]
-  tech: { name: string }[]
+  urls: Url[] | null
+  tech: { name: string }[] | null
   is_owner: boolean
 }
-export interface SelectedUserProfile {
-  profile: {
-    name: string
-    studentNum: string
-    id: number
-    image: string
-    isApproved: boolean
-    isStaff: boolean
-    position: string
-    explain: string
-  }
-  urls: { url: string }[]
-  tech: { name: string }[]
-  isOwner: boolean
-}
+export type Url = { url: string }
+export type UserProfileCamel = ConvertSnakeToCamel<UserProfileReturn>
 
-export const getUserProfile = (userId: string) => {
-  const response = axiosInstance
-    .get(`/user/profile/${userId}`)
-    .then(({ data }) => {
-      return data
-    })
+export const getUserProfile = async (userId: string) => {
+  const response = await axiosInstance.get(`/user/profile/${userId}`)
 
-  return response
+  return response.data
 }
 
 export const USER_PROFILE_KEY = 'profile'
@@ -49,30 +36,14 @@ const useUserProfile = (userId: string) => {
   const userProfileQuery = useQuery<
     UserProfileReturn,
     AxiosError,
-    SelectedUserProfile
+    UserProfileCamel
   >({
     queryFn: () => getUserProfile(userId),
     queryKey: [USER_PROFILE_KEY, userId],
     select: (data) => {
-      const selectedUrls = data.urls.map((url) => url)
-      const selectedTechs = data.tech.map((tech) => tech)
-      const selectedData: SelectedUserProfile = {
-        profile: {
-          name: data.profile.name,
-          studentNum: data.profile.student_num,
-          id: data.profile.id,
-          image: data.profile.image,
-          isApproved: data.profile.is_approved,
-          isStaff: data.profile.is_staff,
-          position: data.profile.position,
-          explain: data.profile.explain,
-        },
-        urls: selectedUrls,
-        tech: selectedTechs,
-        isOwner: data.is_owner,
-      }
+      const convertedData = convertSnakeToCamel(data)
 
-      return selectedData
+      return convertedData
     },
   })
   return userProfileQuery

--- a/what_team_my_team/app/(profile)/profile/[slug]/ProfileSideMenu.tsx
+++ b/what_team_my_team/app/(profile)/profile/[slug]/ProfileSideMenu.tsx
@@ -1,12 +1,39 @@
-const ProfileSideMenu = () => {
+'use client'
+
+import useHandleLogout from '@/_hook/useHandleLogout'
+import { cn } from '@/_lib/utils'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+
+const ProfileSideMenu = ({ userId }: { userId: string }) => {
+  const { handleLogout } = useHandleLogout()
+  const pathname = usePathname()
+
+  const menuItems = [
+    { href: `/profile/${userId}`, label: '프로필' },
+    { href: `/profile/${userId}/active`, label: '내 활동' },
+    { href: `/profile/${userId}/team`, label: '팀 관리' },
+  ]
+
   return (
-    <aside className="hidden flex-col w-full max-w-[240px] md:flex">
+    <aside className="hidden px-2 flex-col w-full max-w-[240px] md:flex">
       <div className="flex flex-col gap-8 mb-40">
-        <span className="text-xl text-gray-6">프로필</span>
-        <span className="text-xl text-gray-6">내 활동</span>
-        <span className="text-xl text-gray-6">팀 관리</span>
+        {menuItems.map((item) => (
+          <Link href={item.href} key={item.href}>
+            <button
+              className={cn('w-full text-left text-xl', {
+                'text-black': pathname === item.href,
+                'text-gray-6': pathname !== item.href,
+              })}
+            >
+              {item.label}
+            </button>
+          </Link>
+        ))}
       </div>
-      <span className="text-xl text-red-6">로그아웃</span>
+      <button className=" text-left text-xl text-red-6" onClick={handleLogout}>
+        로그아웃
+      </button>
     </aside>
   )
 }

--- a/what_team_my_team/app/(profile)/profile/[slug]/_components/BasicInfo.tsx
+++ b/what_team_my_team/app/(profile)/profile/[slug]/_components/BasicInfo.tsx
@@ -2,16 +2,16 @@
 
 import ProfileAvatar from '@/_components/ProfileAvatar'
 import Button from '@/_components/ui/Button'
-import { SelectedUserProfile } from '@/_services/queries/useUserProfile'
+import { UserProfileCamel } from '@/_services/queries/useUserProfile'
 import Link from 'next/link'
 import React from 'react'
 
-const BasicInfo = ({ data }: { data: SelectedUserProfile }) => {
+const BasicInfo = ({ data }: { data: UserProfileCamel }) => {
   return (
-    <div className="flex justify-between mb-12">
+    <div className="flex justify-between items-center mb-12">
       <div className="flex gap-4">
         <ProfileAvatar
-          imgUrl={data?.profile.image}
+          imgUrl={data?.profile.imageUrl}
           alt={data.profile.name}
           size={'large'}
         />
@@ -26,9 +26,9 @@ const BasicInfo = ({ data }: { data: SelectedUserProfile }) => {
         </div>
       </div>
       {data.isOwner && (
-        <Button variant={'lined'}>
-          <Link href={`/profile/${data.profile.id}/setting`}>설정</Link>
-        </Button>
+        <Link href={`/profile/${data.profile.id}/setting`}>
+          <Button variant={'lined'}>설정</Button>
+        </Link>
       )}
     </div>
   )

--- a/what_team_my_team/app/(profile)/profile/[slug]/_components/LinkInfo.tsx
+++ b/what_team_my_team/app/(profile)/profile/[slug]/_components/LinkInfo.tsx
@@ -1,26 +1,31 @@
 'use client'
 
 import LinkAvatar from '@/_components/LinkAvatar'
+import { Url } from '@/_services/queries/useUserProfile'
 import React from 'react'
 
 interface LinkInfoProps {
-  urls: { url: string }[]
+  urls: Url[] | null
 }
 
 const LinkInfo = ({ urls }: LinkInfoProps) => {
   return (
     <div>
       <h3 className="text-base mb-2">링크</h3>
-      <ul className="flex flex-col gap-2">
-        {urls.map(({ url }, idx) => (
-          <li key={`${url}-${idx}`} className="flex items-center gap-2">
-            <LinkAvatar size={'link'} url={url} />
-            <a href={url} className="text-sm ml-2">
-              {url}
-            </a>
-          </li>
-        ))}
-      </ul>
+      {urls ? (
+        <ul className="flex flex-col gap-2">
+          {urls.map(({ url }, idx) => (
+            <li key={`${url}-${idx}`} className="flex items-center gap-2">
+              <LinkAvatar size={'link'} url={url} />
+              <a href={url} className="text-sm ml-2">
+                {url}
+              </a>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <span className="text-sm">없음</span>
+      )}
     </div>
   )
 }

--- a/what_team_my_team/app/(profile)/profile/[slug]/_components/TechInfo.tsx
+++ b/what_team_my_team/app/(profile)/profile/[slug]/_components/TechInfo.tsx
@@ -3,7 +3,7 @@
 import React from 'react'
 
 interface TechInfoProps {
-  tech: { name: string }[]
+  tech: { name: string }[] | null
 }
 
 const TechInfo = ({ tech }: TechInfoProps) => {
@@ -11,9 +11,7 @@ const TechInfo = ({ tech }: TechInfoProps) => {
     <div>
       <h3 className="text-base mb-2">기술 스택</h3>
       <ul className="flex gap-1 border border-gray-4 rounded-sm py-2 px-2">
-        {tech.length === 0 ? (
-          <span>없음</span>
-        ) : (
+        {tech ? (
           tech.map(({ name }, idx) => (
             <li
               key={`${name}-${idx}}`}
@@ -22,6 +20,8 @@ const TechInfo = ({ tech }: TechInfoProps) => {
               {name}
             </li>
           ))
+        ) : (
+          <span className="text-sm">없음</span>
         )}
       </ul>
     </div>

--- a/what_team_my_team/app/(profile)/profile/[slug]/layout.tsx
+++ b/what_team_my_team/app/(profile)/profile/[slug]/layout.tsx
@@ -1,10 +1,15 @@
 import ProfileSideMenu from './ProfileSideMenu'
 
-const layout = ({ children }: Readonly<{ children: React.ReactNode }>) => {
+const layout = ({
+  children,
+  params,
+}: Readonly<{ children: React.ReactNode; params: { slug: string } }>) => {
+  const userId = params.slug
+
   return (
     <div className="flex justify-center w-full">
       <div className="flex w-full max-w-[840px]">
-        <ProfileSideMenu />
+        <ProfileSideMenu userId={userId} />
         {children}
       </div>
     </div>

--- a/what_team_my_team/app/(profile)/profile/[slug]/page.tsx
+++ b/what_team_my_team/app/(profile)/profile/[slug]/page.tsx
@@ -3,24 +3,37 @@ import ProfileContainer from './_components/ProfileContainer'
 import { getQueryClient } from '@/app/getQueryClient'
 import {
   USER_PROFILE_KEY,
-  getUserProfile,
+  UserProfileReturn,
 } from '@/_services/queries/useUserProfile'
 import { dehydrate } from '@tanstack/react-query'
 import Hydrate from '@/_lib/hydrate.client'
+import axios from 'axios'
+import { cookies } from 'next/headers'
 
 const ProfilePage = async ({ params }: { params: { slug: string } }) => {
   const userId = params.slug
+  const cookieStore = cookies()
+  const accessCookie = cookieStore.get('access')?.value
 
   const queryClient = getQueryClient()
-  await queryClient.prefetchQuery({
+  await queryClient.prefetchQuery<UserProfileReturn>({
     queryKey: [USER_PROFILE_KEY, userId],
-    queryFn: () => getUserProfile(userId),
+    queryFn: async () => {
+      const response = await axios.get(
+        `https://api.whatmeow.shop/api/user/profile/${userId}`,
+        {
+          headers: { Authorization: `Bearer ${accessCookie}` },
+        },
+      )
+
+      return response.data
+    },
   })
   const dehydratedState = dehydrate(queryClient)
 
   return (
     <Hydrate state={dehydratedState}>
-      <div className="w-full">
+      <div className="w-full px-2">
         <ProfileContainer userId={userId} />
       </div>
     </Hydrate>


### PR DESCRIPTION
**## #️⃣ 연관된 이슈** 
[#47]

---

**## 📝 작업 내용**
프로필 페이지가 mock 데이터가 아닌 실제 api 통신에서 제대로 렌더링 되지 않던 이슈를 해결하였습니다. (urls와 tech가 null일 때 오류 발생이 원인)
로그아웃 api 메소드를 변경하였습니다.
프로필 사이드 네비게이션의 아이템들에 링크 기능이 동작하게 하였습니다.
프로필 페이지의 프로필을 prefetch 할 때 Auth 정보가 없어 isOwner가 제대로 반영되지 않는 이슈를 해결하였습니다.

---

**## 📢 참고사항**
