### PR TITLE
[#58] 팀 상세페이지가 보이지 않던 이슈 해결

### DIFF
--- a/what_team_my_team/_mocks/datas.ts
+++ b/what_team_my_team/_mocks/datas.ts
@@ -83,40 +83,39 @@ const ProfileData = {
 
 const ProjectDetailData: ProjectDetailReturn = {
   team: {
-    id: 4,
-    leader_id: 2,
-    name: '고양이를 위한 SNS, 왓냥',
-    explain:
-      '#### 이번에 새로운 프로젝트를 진행하고 있습니다!\nFastAPI를 사용하다가 장고도 한 번 써보고 싶은 마음에 무작정 돌입하게 됐는데, 건드는게 생각보다 쉽지 않아 여기저기 공부하면서 하고 있네요.. 장고가 처음이다보니 부족한 지식으로 잘못 기술되거나 보셨을 때 개선의 여지가 있다면 코멘트 부탁드리겠습니다! (__) \n\n이번 프로젝트에서 적용한 인증/인가 방식을 한 번 소개해볼까 합니다.\n글에서는 단순히 로직만 소개하는 것이 아니라 나름대로 구현할 때 살펴봤던 점도 함께 기술해보겠습니다.\n(별로 대단하지는 않고, 조잡하다고 생각합니다만..)\n\n## 흐름도\n\n![](https://velog.velcdn.com/images/taegong_s/post/f1927c1c-ddf5-4abb-824a-a7b3b5576b71/image.png)\n\n전체적인 흐름도입니다. 위에서는 FrontEnd만 표기되어 있지만, 사실 App과 통신할 때 Authorization 헤더를 사용하고 웹에서 프론트와 통신할 때는 쿠키를 사용했습니다. 글 읽으시다가 참고하기 좋으시라고 미리 올려두겠습니다.\n\n> 이번에 앱과 웹 동시에 통신하는 백엔드를 처음 개발해보는데 이게 통상적인 방법인지는 모르겠습니다만 커스텀 헤더를 추가해서 앱에서 온 요청인지 웹에서 온 요청인지 구분하고 있습니다. (api 따로 추가 X)\n\n## 커스텀 미들웨어\nApp에서 통신할 때는 굳이 쿠키를 이용하지 않고 JWT를 주고 받는 방식,\nWeb에서 통신할 때는 쿠키에 JWT를 넣어 주고 받는 방식을 구현하고자 했는데요.\n이를 구현하기 위해서 미들웨어를 따로 추가해줬습니다.\n\n```python\nfrom django.utils.deprecation import MiddlewareMixin\nfrom rest_framework import status\n\n\nclass AttachJWTFromHeaderToCookieMiddleware(MiddlewareMixin):\n    def __init__(self, get_response):\n        super().__init__(get_response)\n        self.API = ["github/login", "callback/github"]\n        self.REFRESH = "token/refresh"\n\n    def process_response(self, request, response):\n        path = request.path_info\n        is_valid = any(api in path for api in self.API)\n        is_refresh = True if self.REFRESH in path else False\n        if (\n            is_valid\n            or is_refresh\n            and (response.status_code == status.HTTP_200_OK or response.status_code == status.HTTP_201_CREATED)\n        ):\n            if request.META.get("HTTP_X_FROM", None) == "web":\n                response.set_cookie("access", response.headers.get("access", None), httponly=True)\n                if is_valid:\n                    del response.headers["access"]\n\n                response.content = response.render().rendered_content\n\n        return response\n\n\nclass AttachJWTFromCookieToHeaderMiddleware(MiddlewareMixin):\n    def __init__(self, get_response):\n        super().__init__(get_response)\n        self.NOT_API = ["github/login", "callback/github"]\n\n    def process_request(self, request):\n        path = request.path_info\n        is_valid = any(api in path for api in self.NOT_API)\n\n        if not is_valid:\n            if request.META.get("HTTP_X_FROM", None) == "web":\n                request.META["HTTP_AUTHORIZATION"] = f"Bearer {request.COOKIES.get(\'access\', None)}"\n\n```\n\n#### AttachJWTFromHeaderToCookieMiddleware\n\n말 그대로 헤더에서 쿠키로 JWT를 붙여주는 미들웨어입니다.\n서버에서 클라이언트 측으로 JWT를 보낼 때는 현재 회원가입/로그인, 토큰 리프레싱 API 밖에 없기 때문에 요청 Path에 위 태스크의 API 주소가 들어있다면 실행되도록 커스텀했습니다.\n\n웹에서 온 요청일 때만 리스폰스의 헤더에서 쿠키로 JWT를 옮겨줍니다.\n\n#### AttachJWTFromCookieToHeaderMiddleware\n\n위의 미들웨어와 정반대의 일을 하는 미들웨어입니다.\n클라이언트 쪽에서 JWT가 들어오는 요청은 회원가입/로그인 요청을 제외한 모든 요청입니다.\n\n웹에서 온 요청일 때만 리퀘스트의 쿠키에서 헤더로 JWT를 옮겨줍니다.\n\n### 왜? 굳이 쿠키에서 헤더로..?\n\n옮겼느냐!라고 생각하실 분들이 있으실텐데요. (잘 아시는 분들이라면 부럽습니다. 저는 헤맸었거든요)\n\nDRF에서 JWT를 사용하면서 사용자를 식별하기 위해\n```python\nrest_framework_simplejwt.authentication.JWTAuthentication\n```\n를 사용합니다. 저도 이 인증방식을 기본으로 채택해놨구요.\n이 JWTAuthentication을 조금 살펴봅시다.\n\n```python\ndef authenticate(self, request: Request) -> Optional[Tuple[AuthUser, Token]]:\n        header = self.get_header(request)\n\n        if header is None:\n            return None\n\n        raw_token = self.get_raw_token(header)\n        if raw_token is None:\n            return None\n\n        validated_token = self.get_validated_token(raw_token)\n\n        return self.get_user(validated_token), validated_token\n        \ndef get_header(self, request: Request) -> bytes:\n        """\n        Extracts the header containing the JSON web token from the given\n        request.\n        """\n        header = request.META.get(api_settings.AUTH_HEADER_NAME)\n        if isinstance(header, str):\n            # Work around django test client oddness\n            header = header.encode(HTTP_HEADER_ENCODING)\n```\n\nJWTAuthentication의 일부 함수들인데요.\n음.. 쿠키로 인증하는 내용은 없어보입니다? 읽어보니 기본 인증 헤더(Authorization)으로부터 JWT를 가져오네요. 물론 JWTAuthentication을 상속받아 쿠키에서도 토큰을 가져오도록 커스텀 할 수도 있겠습니다만은, 저는 미들웨어에서 그냥 헤더로 넣어버리는 방법을 선택해봤습니다.\n\n> JWTAuthentication를 통과하고나면 request.user에 유저 객체 또는 AnonymousUser가 들어갑니다. 이를 통해 APIView에서 permission_classes로 권한 설정을 쉽게 할 수 있었어요!\n\n```python\n    def get_validated_token(self, raw_token: bytes) -> Token:\n        """\n        Validates an encoded JSON web token and returns a validated token\n        wrapper object.\n        """\n        messages = []\n        for AuthToken in api_settings.AUTH_TOKEN_CLASSES:\n            try:\n                return AuthToken(raw_token)\n            except TokenError as e:\n                messages.append(\n                    {\n                        "token_class": AuthToken.__name__,\n                        "token_type": AuthToken.token_type,\n                        "message": e.args[0],\n                    }\n                )\n\n        raise InvalidToken(\n            {\n                "detail": _("Given token not valid for any token type"),\n                "messages": messages,\n            }\n        )\n\n```\n\nauthenticate 함수 내에서 실행되는 토큰 확인 함수입니다. 여기서 정상적인 토큰인지, 토큰이 만료되었는지 확인하게 됩니다. simple_jwt 라이브러리에서 정의된 AuthToken 클래스에서 확인합니다. 여기서 위 흐름도의 401을 반환하는 경우의 수를 충족하겠죠? get_user 함수를 통해 유저 객체를 반환해줍니다.\n\n## 드디어 View로..\n\nDRF에서 APIView를 사용해 유저의 권한을 쉽게 확인할 수 있습니다.\n아래에 View를 두 개 올려둘게요.\n```python\nclass UserManageView(APIView):\n    serializer_class = ApproveUserSerializer\n    permission_classes = [IsAdminUser]\n\n    def get(self, request):\n        queryset = User.objects.filter(is_approved=False)\n        if queryset:\n            serializer = self.serializer_class(queryset, many=True)\n            return Response(serializer.data)\n        else:\n            return Response({"error": "No Content"}, status=status.HTTP_404_NOT_FOUND)\n\n    def patch(self, request, *args, **kwargs):\n        user_id = kwargs.get("user_id")\n        user = User.objects.get(id=user_id)\n\n        serializer = ApproveUserSerializer(user, data={"is_approved": True}, partial=True)\n        if serializer.is_valid():\n            serializer.save()\n            return Response({"success": True}, status=status.HTTP_202_ACCEPTED)\n\n        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)\n\nclass GithubOAuthCallBackView(APIView):\n    permission_classes = [AllowAny]\n\n    def get(self, request: Request):\n        if code := request.GET.get("code"):\n            response = self.send_code_to_github_login_view(code)\n            if response.status_code == 200:\n                return Response(response.json(), status=status.HTTP_200_OK)\n            return Response(\n                {"error": "Failed to process with GithubLoginView"},\n                status=response.status_code,\n            )\n\n    def send_code_to_github_login_view(self, code: str):\n        url = "http://localhost:8000/api/auth/github/login"\n        payload = {"code": code}\n        headers = {"Content-Type": "application/json"}\n        response = requests.post(url, json=payload, headers=headers)\n\n        return response\n```\n\n#### GithubOAuthCallBackView\n이 뷰는 소셜 로그인에서 콜백 부분을 담당하는 부분입니다.\n',
-    genre: 'app',
-    like: 0,
-    version: 0,
-    image:
-      'https://wtnt-bucket.s3.ap-northeast-2.amazonaws.com/team/test2/image.jpg',
-    leader_name: '강태원',
+    id: 31,
+    leader_info: {
+      name: '강태원',
+      id: 1112,
+      image_url:
+        'https://wtnt-bucket.s3.ap-northeast-2.amazonaws.com/user/1112/thumnail.jpg',
+    },
+    title: '불멸의 태공스',
+    explain: '### 호정제국의 침략을 막아라!',
+    genre: '게임',
+    like: 1,
+    version: 1,
+    image_url:
+      'https://wtnt-bucket.s3.ap-northeast-2.amazonaws.com/team/d7a3677a-87de-4e0d-8b05-d207507c9179/image.jpg',
+    view: 3,
+    category: [
+      {
+        id: 57,
+        tech: '언리얼엔진',
+        need_num: 4,
+        current_num: 0,
+      },
+      {
+        id: 56,
+        tech: '스토리개발',
+        need_num: 1,
+        current_num: 0,
+      },
+    ],
+    urls: ['www.daum.net', 'https://github.com/fnzksxl123'],
   },
-  tech: [
-    {
-      id: 4,
-      tech: '자바스프링',
-      need_num: 2,
-      current_num: 0,
-    },
-    {
-      id: 3,
-      tech: '크로스플랫폼',
-      need_num: 3,
-      current_num: 0,
-    },
-    {
-      id: 5,
-      tech: '안드로이드',
-      need_num: 3,
-      current_num: 0,
-    },
-  ],
-  url: [],
-  is_leader: true,
+  is_leader: false,
+  is_like: false,
 }
 const ApplyResponseData = {
   id: 4,

--- a/what_team_my_team/_services/mutations/useApplyProject.ts
+++ b/what_team_my_team/_services/mutations/useApplyProject.ts
@@ -11,21 +11,18 @@ interface ApplyProjectResponse {
   tech: string
 }
 interface ApplyProjectVariables {
-  projectId: string
+  categoryId: number
   content: string
 }
 
-const applyProject = (data: ApplyProjectVariables) => {
-  const { content, projectId } = data
+const applyProject = async ({ categoryId, content }: ApplyProjectVariables) => {
   const body = {
     bio: content,
   }
 
-  const response = axiosInstance
-    .post(`/team/apply/${projectId}`, body)
-    .then(({ data }) => data)
+  const response = await axiosInstance.post(`/apply/${categoryId}`, body)
 
-  return response
+  return response.data
 }
 
 const useApplyProject = () => {

--- a/what_team_my_team/_services/queries/useProjectDetail.ts
+++ b/what_team_my_team/_services/queries/useProjectDetail.ts
@@ -1,103 +1,63 @@
 import axiosInstance from '@/_lib/axios'
+import {
+  convertSnakeToCamel,
+  ConvertSnakeToCamel,
+} from '@/_utils/convertSnakeToCamel'
 import { useQuery } from '@tanstack/react-query'
 import { AxiosError } from 'axios'
 
 export interface ProjectDetailReturn {
   team: {
     id: number
-    leader_id: number
-    name: string
+    leader_info: {
+      name: string
+      id: number
+      image_url: string
+    }
+    title: string
     explain: string
     genre: string
     like: number
     version: number
-    image: string
-    leader_name: string
+    image_url: string
+    view: number
+    category: Category[]
+    urls: string[]
   }
-  tech: {
-    id: number
-    tech: string
-    need_num: number
-    current_num: number
-  }[]
-  url: []
   is_leader: boolean
+  is_like: boolean
 }
-export interface SelectedProjectDetail {
-  team: Team
-  tech: Tech[]
-  url: []
-  isLeader: boolean
-}
-export interface Team {
-  id: number
-  leaderId: number
-  name: string
-  explain: string
-  genre: string
-  like: number
-  version: number
-  image: string
-  leaderName: string
-}
-export interface Tech {
+
+export type Category = {
   id: number
   tech: string
-  needNum: number
-  currentNum: number
+  need_num: number
+  current_num: number
 }
 
-export const getProjectDetail = (teamId: string) => {
-  const response = axiosInstance
-    .get(`/team/detail/${teamId}`)
-    .then(({ data }) => data)
+export const ProjectDetailApi = async (teamId: string) => {
+  const response = await axiosInstance.get(`/team/detail/${teamId}`)
 
-  return response
+  console.log(response.data)
+  return response.data
 }
 
 export const PROJECT_DETAIL_KEY = 'project-detail'
 
-const useProjectDetail = (teamId: string) => {
+export const useProjectDetail = ({ teamId }: { teamId: string }) => {
   const projectDetailQuery = useQuery<
     ProjectDetailReturn,
     AxiosError,
-    SelectedProjectDetail
+    ConvertSnakeToCamel<ProjectDetailReturn>
   >({
-    queryFn: () => getProjectDetail(teamId),
+    queryFn: () => ProjectDetailApi(teamId),
     queryKey: [PROJECT_DETAIL_KEY, teamId],
     select: (data) => {
-      const selectedTech: Tech[] = data.tech.map(
-        ({ id, tech, need_num, current_num }) => {
-          return {
-            id: id,
-            tech: tech,
-            needNum: need_num,
-            currentNum: current_num,
-          }
-        },
-      )
-      const selectedData: SelectedProjectDetail = {
-        team: {
-          id: data.team.id,
-          leaderId: data.team.leader_id,
-          name: data.team.name,
-          explain: data.team.explain,
-          genre: data.team.genre,
-          like: data.team.like,
-          version: data.team.version,
-          image: data.team.image,
-          leaderName: data.team.leader_name,
-        },
-        tech: selectedTech,
-        url: [...data.url],
-        isLeader: data.is_leader,
-      }
+      const convertedData = convertSnakeToCamel(data)
 
-      return selectedData
+      return convertedData
     },
   })
 
   return projectDetailQuery
 }
-
-export default useProjectDetail

--- a/what_team_my_team/_stores/atoms/position.ts
+++ b/what_team_my_team/_stores/atoms/position.ts
@@ -1,0 +1,3 @@
+import { atom } from 'jotai'
+
+export const selectedPositionIdAtom = atom<number | null>(null)

--- a/what_team_my_team/app/(project)/project/[slug]/_components/LinkList.tsx
+++ b/what_team_my_team/app/(project)/project/[slug]/_components/LinkList.tsx
@@ -15,7 +15,7 @@ const LinkList = ({ urls }: LinkListProps) => {
         {urls.map((url, idx) => (
           <li key={`${url}-${idx}`} className="flex items-center gap-2">
             <LinkAvatar size={'link'} url={url} />
-            <a href={url} className="text-sm ml-2">
+            <a href={url} className="text-sm ml-2" target="_blank">
               {url}
             </a>
           </li>

--- a/what_team_my_team/app/(project)/project/[slug]/_components/PositionItem.tsx
+++ b/what_team_my_team/app/(project)/project/[slug]/_components/PositionItem.tsx
@@ -1,26 +1,30 @@
 'use client'
 
 import Button from '@/_components/ui/Button'
-import { Tech } from '@/_services/queries/useProjectDetail'
+import { Category } from '@/_services/queries/useProjectDetail'
 import { applyDialogAtom } from '@/_stores/atoms/dialog'
+import { selectedPositionIdAtom } from '@/_stores/atoms/position'
+import { ConvertSnakeToCamel } from '@/_utils/convertSnakeToCamel'
 import { useSetAtom } from 'jotai'
 import React from 'react'
 
 interface PositionItemProps {
-  position: Tech
+  position: ConvertSnakeToCamel<Category>
 }
 
 const PositionItem = ({ position }: PositionItemProps) => {
   const setOpen = useSetAtom(applyDialogAtom)
+  const setSelectedPositionId = useSetAtom(selectedPositionIdAtom)
 
   const handleDialogState = () => {
     setOpen(true)
+    setSelectedPositionId(position.id)
   }
 
   return (
     <div className="flex justify-between items-center">
       <div className="flex flex-col gap-1">
-        <span className="text-sm text-indigo-6">개발</span>
+        {/* <span className="text-sm text-indigo-6">개발</span> */}
         <span className="text-sm font-medium">{position.tech}</span>
         <div className="flex text-xs text-gray-6 gap-2">
           <span>현원 {position.currentNum}</span>

--- a/what_team_my_team/app/(project)/project/[slug]/_components/PositionList.tsx
+++ b/what_team_my_team/app/(project)/project/[slug]/_components/PositionList.tsx
@@ -1,11 +1,12 @@
 'use client'
 
-import { Tech } from '@/_services/queries/useProjectDetail'
 import React from 'react'
 import PositionItem from './PositionItem'
+import { Category } from '@/_services/queries/useProjectDetail'
+import { ConvertSnakeToCamel } from '@/_utils/convertSnakeToCamel'
 
 interface PositionListProps {
-  positions: Tech[]
+  positions: ConvertSnakeToCamel<Category[]>
 }
 
 const PositionList = ({ positions }: PositionListProps) => {

--- a/what_team_my_team/app/(project)/project/[slug]/_components/PrimaryInfo.tsx
+++ b/what_team_my_team/app/(project)/project/[slug]/_components/PrimaryInfo.tsx
@@ -1,20 +1,26 @@
 'use client'
 
-import { Team } from '@/_services/queries/useProjectDetail'
+import { ProjectDetailReturn } from '@/_services/queries/useProjectDetail'
+import { ConvertSnakeToCamel } from '@/_utils/convertSnakeToCamel'
+import Link from 'next/link'
 import React from 'react'
 
 interface PrimaryInfoProps {
-  team: Team
+  team: ConvertSnakeToCamel<ProjectDetailReturn>
 }
 
 const PrimaryInfo = ({ team }: PrimaryInfoProps) => {
   return (
-    <div className=" border-b-[1px] border-gray-4 py-4">
-      <h3 className="text-2xl font-bold">{team.name}</h3>
-      <div className="flex gap-1 text-sm text-gray-6">
-        <span>{team.leaderName}</span>
-        <span>조회수 0</span>
-        <span>관심가지는 사람 0</span>
+    <div className=" border-b border-gray-4 py-3">
+      <h3 className="text-2xl font-bold mb-2">{team.team.title}</h3>
+      <div className="flex gap-4 text-sm text-gray-6">
+        <Link href={`/profile/${team.team.leaderInfo.id}`}>
+          {team.team.leaderInfo.name}
+        </Link>
+        <div className="flex gap-1">
+          <span>조회수 {team.team.view}</span>
+          <span>스크랩 {team.team.like}</span>
+        </div>
       </div>
     </div>
   )

--- a/what_team_my_team/app/(project)/project/[slug]/_components/ProjectContainer.tsx
+++ b/what_team_my_team/app/(project)/project/[slug]/_components/ProjectContainer.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React from 'react'
-import useProjectDetail from '@/_services/queries/useProjectDetail'
+import { useProjectDetail } from '@/_services/queries/useProjectDetail'
 import PositionList from './PositionList'
 import ProjectExplain from './ProjectExplain'
 import PrimaryInfo from './PrimaryInfo'
@@ -10,22 +10,22 @@ import LinkList from './LinkList'
 import ApplyDialog from './ApplyDialog'
 
 interface ProjectContainerProps {
-  projectId: string
+  teamId: string
 }
 
-const ProjectContainer = ({ projectId }: ProjectContainerProps) => {
-  const { data, isLoading } = useProjectDetail(projectId)
+const ProjectContainer = ({ teamId }: ProjectContainerProps) => {
+  const { data, isLoading } = useProjectDetail({ teamId })
 
   return (
-    <div className="flex justify-between w-full max-w-[1060px]">
-      <ApplyDialog projectId={projectId} />
+    <div className="flex justify-between w-full max-w-[1048px] px-2">
+      <ApplyDialog teamId={teamId} />
       {isLoading && <div className="">...로딩중</div>}
       {data && (
         <div className="flex flex-col gap-8 w-full px-6 py-12 md:flex-1 md:w-[330px]">
-          <PrimaryInfo team={data.team} />
-          <PositionList positions={data.tech} />
+          <PrimaryInfo team={data} />
+          <PositionList positions={data.team.category} />
           <ProjectExplain explain={data.team.explain} />
-          <LinkList urls={data.url} />
+          <LinkList urls={data.team.urls} />
         </div>
       )}
       <SideMenu />

--- a/what_team_my_team/app/(project)/project/[slug]/_components/ProjectExplain.tsx
+++ b/what_team_my_team/app/(project)/project/[slug]/_components/ProjectExplain.tsx
@@ -11,7 +11,12 @@ const ProjectExplain = ({ explain }: ProjectExplainProps) => {
   return (
     <div>
       <h3 className="text-xl font-bold mb-2">프로젝트 설명</h3>
-      <MDEditor.Markdown source={explain} style={{ whiteSpace: 'pre-wrap' }} />
+      <div data-color-mode="light">
+        <MDEditor.Markdown
+          source={explain}
+          style={{ whiteSpace: 'pre-wrap' }}
+        />
+      </div>
     </div>
   )
 }

--- a/what_team_my_team/app/(project)/project/[slug]/_components/SideMenu.tsx
+++ b/what_team_my_team/app/(project)/project/[slug]/_components/SideMenu.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 
 const SideMenu = () => {
   return (
-    <div className="hidden flex-shrink-0 w-60 md:block ">
+    <div className="hidden flex-shrink-0 w-60 md:block">
       <aside className="w-60 fixed">
         <div className="flex flex-col gap-2">
           <Button className="">지원하기</Button>

--- a/what_team_my_team/app/(project)/project/[slug]/page.tsx
+++ b/what_team_my_team/app/(project)/project/[slug]/page.tsx
@@ -2,11 +2,11 @@ import React from 'react'
 import ProjectContainer from './_components/ProjectContainer'
 
 const ProjectDetailPage = ({ params }: { params: { slug: string } }) => {
-  const projectId = params.slug
+  const teamId = params.slug
 
   return (
     <div className="w-full flex flex-col items-center">
-      <ProjectContainer projectId={projectId} />
+      <ProjectContainer teamId={teamId} />
     </div>
   )
 }

--- a/what_team_my_team/stories/PositionItem.stories.ts
+++ b/what_team_my_team/stories/PositionItem.stories.ts
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import PositionItem from '@/app/(project)/project/[slug]/_components/PositionItem'
-import { Tech } from '@/_services/queries/useProjectDetail'
 
 const meta = {
   title: 'Components/PositionItem',
@@ -14,7 +13,7 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
-const examplePosition: Tech = {
+const examplePosition = {
   id: 4,
   tech: '자바스프링',
   needNum: 2,


### PR DESCRIPTION
**## #️⃣ 연관된 이슈** 
[#58]

---

**## 📝 작업 내용**
팀 상세 페이지를 불러오는 api return type이 일치하지 않던 문제를 해결하였습니다.
<img width="1511" alt="스크린샷 2024-08-28 오후 2 05 07" src="https://github.com/user-attachments/assets/57e1dcd3-e60d-4fbe-9dda-77abc28d919f">

관련 링크의 링크 클릭 시 새탭이 열리도록 하였습니다.
팀 지원 api 의 변경점을 적용하여 팀 지원이 가능하도록 하였습니다.

---

**## 📢 참고사항**
