### PR TITLE
[#59] 상단 네비게이션 팀 생성 버튼 추가

### DIFF
--- a/what_team_my_team/_components/Navigation.tsx
+++ b/what_team_my_team/_components/Navigation.tsx
@@ -24,15 +24,22 @@ const Navigation = () => {
             height={30}
           />
         </Link>
-        {isLoggedIn && user ? (
-          <ProfileMenu user={user} />
-        ) : (
-          <Link href={'/signin'}>
-            <Button variant={'lined'} size={'sm'}>
-              로그인
-            </Button>
-          </Link>
-        )}
+        <div className="flex items-center gap-2">
+          {isLoggedIn && (
+            <Link href={'/teamAdd'}>
+              <Button size={'sm'}>팀 생성</Button>
+            </Link>
+          )}
+          {isLoggedIn && user ? (
+            <ProfileMenu user={user} />
+          ) : (
+            <Link href={'/signin'}>
+              <Button variant={'lined'} size={'sm'}>
+                로그인
+              </Button>
+            </Link>
+          )}
+        </div>
       </nav>
     </header>
   )


### PR DESCRIPTION
**## #️⃣ 연관된 이슈** 
[#59]

---

**## 📝 작업 내용**
로그인 시 상단 네비게이션에 팀 생성 버튼이 보이도록 하였습니다.
<img width="1511" alt="스크린샷 2024-08-28 오후 2 40 19" src="https://github.com/user-attachments/assets/cdf78c51-448e-48fc-b9cd-6fe8c734f986">


---
