### PR TITLE
[#62] 프로필 페이지 내 관련 링크가 보이지 않던 이슈 해결

### DIFF
--- a/what_team_my_team/_mocks/datas.ts
+++ b/what_team_my_team/_mocks/datas.ts
@@ -53,13 +53,13 @@ const ProfileData = {
     name: '강태원',
     student_num: '201811318',
     id: 2,
-    image: 'https://avatars.githubusercontent.com/u/71972587?v=4',
+    image_url: 'https://avatars.githubusercontent.com/u/71972587?v=4',
     is_approved: false,
     is_staff: false,
     position: '백엔드',
     explain: '열심히 하겠습니다!',
   },
-  urls: [
+  url: [
     {
       url: 'https://velog.io/@taegong_s',
     },

--- a/what_team_my_team/_services/queries/useUserProfile.ts
+++ b/what_team_my_team/_services/queries/useUserProfile.ts
@@ -17,7 +17,7 @@ export interface UserProfileReturn {
     position: string
     explain: string
   }
-  urls: Url[] | null
+  url: Url[] | null
   tech: { name: string }[] | null
   is_owner: boolean
 }

--- a/what_team_my_team/app/(profile)/profile/[slug]/_components/ProfileContainer.tsx
+++ b/what_team_my_team/app/(profile)/profile/[slug]/_components/ProfileContainer.tsx
@@ -25,7 +25,7 @@ const ProfileContainer = ({ userId }: ProfileContainerProps) => {
             <PositionInfo position={data.profile.position} />
             <TechInfo tech={data.tech} />
             <MyExplainInfo explain={data.profile.explain} />
-            <LinkInfo urls={data.urls} />
+            <LinkInfo urls={data.url} />
           </div>
         </div>
       )}

--- a/what_team_my_team/app/(profile)/profile/[slug]/_components/TechInfo.tsx
+++ b/what_team_my_team/app/(profile)/profile/[slug]/_components/TechInfo.tsx
@@ -11,7 +11,7 @@ const TechInfo = ({ tech }: TechInfoProps) => {
     <div>
       <h3 className="text-base mb-2">기술 스택</h3>
       <ul className="flex gap-1 border border-gray-4 rounded-sm py-2 px-2">
-        {tech ? (
+        {tech && tech?.length > 0 ? (
           tech.map(({ name }, idx) => (
             <li
               key={`${name}-${idx}}`}


### PR DESCRIPTION
**## #️⃣ 연관된 이슈** 
[#62]

---

**## 📝 작업 내용**
기존 data type 과 실제 api return type이 불일치 하여 프로필 페이지의 관련 링크가 제대로 보이지 않던 이슈를 해결하였습니다.

---

**## 📢 참고사항**
기술 스택이 없을 때 "없음" 이 나오지 않던 이슈도 추가로 해결