### PR TITLE
[#63] 팀 생성 api 후처리 로직

### DIFF
--- a/what_team_my_team/app/teamAdd/_components/FormContainer.tsx
+++ b/what_team_my_team/app/teamAdd/_components/FormContainer.tsx
@@ -91,7 +91,13 @@ const FormContainer = () => {
       formData.append('urls', urls)
     }
 
-    mutate(formData)
+    mutate(formData, {
+      onSuccess: (response) => {
+        alert('성공적으로 생성되었습니다. 승인을 기다려주세요.')
+        router.push(`/project/${response.team.id}`)
+      },
+      onError: () => alert('팀 생성에 실패하였습니다.'),
+    })
   }
 
   return (


### PR DESCRIPTION
**## #️⃣ 연관된 이슈** 
[#63]

---

**## 📝 작업 내용**
팀 생성 api 의 후처리 로직입니다.
<img width="450" alt="스크린샷 2024-08-28 오후 4 09 44" src="https://github.com/user-attachments/assets/5e8ecbe5-7871-433b-82c4-e1df9e863fc5">

생성에 성공하면 alert 창이 뜨고 확인을 누를 시 해당 팀의 detail 페이지로 이동하게 됩니다.

---

**## 📢 참고사항**
실패 시 간단하게 에러가 발생했다는 alert 를 보여주게 하였습니다.