### PR TITLE
[#68] middleware 를 통한 route protect 구현

### DIFF
--- a/what_team_my_team/middleware.ts
+++ b/what_team_my_team/middleware.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server'
+import { type NextRequest } from 'next/server'
+
+export async function middleware(req: NextRequest) {
+  const response = NextResponse.next()
+
+  const path = req.nextUrl.pathname
+
+  const isProtectedRoute =
+    path === '/' ? false : protectedRoutes.some((route) => path.includes(route))
+  const isAuthRoute =
+    path === '/' ? false : authRoutes.some((route) => path.includes(route))
+
+  const isAuthenticated = req.cookies.get('access')?.value ? true : false
+
+  if (isAuthRoute && isAuthenticated) {
+    const homeURL = new URL('', req.nextUrl.origin)
+    return NextResponse.redirect(homeURL.toString())
+  }
+
+  if (isProtectedRoute && !isAuthenticated) {
+    const signinURL = new URL(SIGN_IN_PATH, req.nextUrl.origin)
+    return NextResponse.redirect(signinURL.toString())
+  }
+
+  return response
+}
+
+export const config = {
+  matcher: [
+    '/((?!api|_next/static|_next/image|assets|favicon.ico|sitemap.xml|robots.txt).*)',
+  ],
+}
+
+const SIGN_IN_PATH = '/signin'
+const SIGN_UP_PATH = '/signup'
+const AUTH_PATH = '/oauth'
+
+const authRoutes = [SIGN_IN_PATH, SIGN_UP_PATH, AUTH_PATH]
+const protectedRoutes = ['/setting', '/manage', '/teamAdd', '/teamManage', '']


### PR DESCRIPTION
**## #️⃣ 연관된 이슈** 
[#68]

---

**## 📝 작업 내용**
nextjs 의 middleware 를 통해 route protect를 구현하였습니다.

nextRequest 에서 'access' 쿠키에 대한 값이 존재하면 Auth와 관련된 라우터에 접근시 '/' 으로 redirect 합니다.
'access' 쿠키에 대한 값이 존재하지 않는다면 Protect 해야되는 라우터에 접근시 '/signin' 으로 redirect 합니다.

---

**## 📢 참고사항**
