### PR TITLE
[#87] 이미지 드래그 앤 드롭 기능 추가

### DIFF
--- a/what_team_my_team/_hook/useDragDrop.ts
+++ b/what_team_my_team/_hook/useDragDrop.ts
@@ -1,0 +1,33 @@
+import { useState } from 'react'
+
+export function useDragDrop() {
+  const [isActive, setActive] = useState(false)
+
+  const handleDragStart = () => setActive(true)
+  const handleDragEnd = () => setActive(false)
+  const handleDragOver = (event: React.DragEvent) => {
+    event.preventDefault()
+  }
+  const handleDrop = (
+    event: React.DragEvent,
+    dropCallback: (file: FileList) => void,
+  ) => {
+    event.preventDefault()
+
+    const { files } = event.dataTransfer
+    if (!files || files.length === 0) {
+      return
+    }
+
+    dropCallback && dropCallback(files)
+    setActive(false)
+  }
+
+  return {
+    isActive,
+    handleDragStart,
+    handleDragEnd,
+    handleDrop,
+    handleDragOver,
+  }
+}

--- a/what_team_my_team/app/teamAdd/_components/ImageForm.tsx
+++ b/what_team_my_team/app/teamAdd/_components/ImageForm.tsx
@@ -4,14 +4,24 @@ import Button from '@/_components/ui/Button'
 import React, { useState } from 'react'
 import { Control, useController } from 'react-hook-form'
 import { TeamAddFormValueType } from './FormContainer'
+import { useDragDrop } from '@/_hook/useDragDrop'
 
 interface ImageFormProps {
   control: Control<TeamAddFormValueType>
 }
 
 const ImageForm = ({ control }: ImageFormProps) => {
+  const { handleDragStart, handleDragEnd, handleDrop, handleDragOver } =
+    useDragDrop()
   const [image, setImage] = useState<string | undefined>()
   const { field } = useController({ name: 'image', control })
+
+  const changeImageField = (file: File | FileList) => {
+    field.onChange(file)
+  }
+  const changeImagePreview = (imageUrl: string) => {
+    setImage(imageUrl)
+  }
 
   const handleChangeFileInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { files } = e.target
@@ -19,10 +29,17 @@ const ImageForm = ({ control }: ImageFormProps) => {
       return
     }
 
-    field.onChange(files)
+    changeImageField(files)
 
     const ImageUrl = URL.createObjectURL(files[0])
-    setImage(ImageUrl)
+    changeImagePreview(ImageUrl)
+  }
+
+  const handleDropAfter = (files: FileList) => {
+    changeImageField(files)
+
+    const ImageUrl = URL.createObjectURL(files[0])
+    changeImagePreview(ImageUrl)
   }
 
   return (
@@ -33,6 +50,10 @@ const ImageForm = ({ control }: ImageFormProps) => {
           <label
             htmlFor="imageInput"
             className="relative block border w-full h-full"
+            onDragEnter={handleDragStart}
+            onDragEnd={handleDragEnd}
+            onDrop={(event) => handleDrop(event, handleDropAfter)}
+            onDragOver={handleDragOver}
           >
             <input
               id="imageInput"


### PR DESCRIPTION
**## #️⃣ 연관된 이슈** 
[#87]

---

**## 📝 작업 내용**
이미지 input 에 대해 드래그 앤 드롭으로 이미지를 변경할 수 있는 로직을 추가하였습니다.



---

**## 📢 참고사항**
현재는 팀 생성페이지의 이미지 추가에 대해서만 적용하였습니다.